### PR TITLE
fix bug: overlay not dismiss

### DIFF
--- a/lib/search_widget.dart
+++ b/lib/search_widget.dart
@@ -108,7 +108,9 @@ class MySingleChoiceSearchState<T> extends State<SearchWidget<T>> {
         }
         _tempList.addAll(filterList);
         if (overlayEntry == null) {
-          onTap();
+          if (_focusNode.hasFocus) {
+            onTap();
+          }
         } else {
           overlayEntry.markNeedsBuild();
         }


### PR DESCRIPTION
the overlay is dismissed when tapping outside of the textfield to dismiss keyboard